### PR TITLE
allow exclusion of symlink paths

### DIFF
--- a/nose_exclude.py
+++ b/nose_exclude.py
@@ -122,9 +122,9 @@ class NoseExclude(Plugin):
     def wantDirectory(self, dirname):
         """Check if directory is eligible for test discovery"""
         # In case of symbolic paths
-        dirname = os.path.realpath(dirname)
+        real_path = os.path.realpath(dirname)
 
-        if dirname in self.exclude_dirs:
+        if dirname in self.exclude_dirs or real_path in self.exclude_dirs:
             log.debug("excluded: %s" % dirname)
             return False
         else:

--- a/test_more_dirs/test_not_me_external/test.py
+++ b/test_more_dirs/test_not_me_external/test.py
@@ -1,0 +1,3 @@
+
+def test_i_should_never_run():
+    assert False


### PR DESCRIPTION
keeps the behavior or excluding symlink's `real_path` as well as excluding the `symlink` itself

_Note_: `PluginTester` magic gave me a hard time, hence the closure / ref keeping in new test case.

attempts to fix #7
