### PR TITLE
return None to not influence a test running

### DIFF
--- a/nose_exclude.py
+++ b/nose_exclude.py
@@ -150,7 +150,7 @@ class NoseExclude(Plugin):
         try:
             cls = get_method_class(meth)
         except AttributeError:
-            return False
+            return None
 
         fqn = '%s.%s.%s' % (cls.__module__, cls.__name__, meth.__name__)
         if fqn in self.exclude_tests:

--- a/tests.py
+++ b/tests.py
@@ -224,5 +224,28 @@ class TestNoseExcludeTestModule(PluginTester, unittest.TestCase):
     def test_tests_excluded(self):
         assert 'Ran 3 tests' in self.output
 
+
+class TestNoseDoesNotExcludeTestClass(PluginTester, unittest.TestCase):
+    """Test nose-exclude tests by class"""
+
+    activate = "--exclude-test=test_dirs.unittest.test"
+    plugins = [NoseExclude()]
+    suitepath = os.path.join(os.getcwd(), 'test_dirs/unittest')
+
+    def setUp(self):
+        def mock_get_method_class(meth):
+            raise AttributeError('foobar')
+        import nose_exclude
+        self.old_get_method_class = nose_exclude.get_method_class
+        nose_exclude.get_method_class = mock_get_method_class
+        super(TestNoseDoesNotExcludeTestClass, self).setUp()
+
+    def tearDown(self):
+        import nose_exclude
+        nose_exclude.get_method_class = self.old_get_method_class
+
+    def test_tests_not_excluded(self):
+        assert 'Ran 3 tests' in self.output
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Added a testcase demonstrating that tests will be skipped when `False` is returned. This change returns `None` to prevent tests from being skipped when they are not in `self.exclude_tests`.

More info:
https://github.com/nose-devs/nose/blob/c1160f2855544b9adc8270068d03fba08987584e/nose/plugins/base.py#L700
