### PR TITLE
Add an option for excluding tests by superclass.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,7 +56,8 @@ Excluding Specific Test Methods and Classes
 -------------------------------------------
 
 Tests can now be excluded by specifying their fully qualified test paths.
-Tests can be excluded using either ``--exclude-test`` or ``--exclude-test-file``.
+Tests can be excluded using ``--exclude-test``, ``--exclude-test-file``, or
+``--exclude-test-superclass``.
 
 To exclude test methods:
 
@@ -65,6 +66,10 @@ To exclude test methods:
 To exclude test classes:
 
 ``--exclude-test=module1.module2.TestClass``
+
+To exclude a test class, and all classes that inherit from it:
+
+``--exclude-test-superclass=module1.module2.TestClass``
 
 To exclude test functions:
 

--- a/nose_exclude.py
+++ b/nose_exclude.py
@@ -57,6 +57,13 @@ class NoseExclude(Plugin):
             help="A file containing a list of fully qualified names of \
                 test methods or classes to exclude from test discovery.")
 
+        parser.add_option(
+            str("--exclude-test-superclass"), action="append",
+            dest="exclude_superclasses",
+            default=[],
+            help="Fully qualified name of test superclass to exclude \
+            from test discovery.")
+
     def _force_to_abspath(self, pathname, root):
         if os.path.isabs(pathname):
             abspath = pathname
@@ -80,6 +87,7 @@ class NoseExclude(Plugin):
 
         self.exclude_dirs = {}
         self.exclude_tests = options.exclude_tests[:]
+        self.exclude_superclasses = options.exclude_superclasses[:]
 
         # preload directories from file
         if options.exclude_dir_file:
@@ -93,7 +101,7 @@ class NoseExclude(Plugin):
             exc_tests = self._load_from_file(options.exclude_test_file)
             self.exclude_tests.extend(exc_tests)
 
-        if not options.exclude_dirs and not self.exclude_tests:
+        if not options.exclude_dirs and not self.exclude_tests and not self.exclude_superclasses:
             self.enabled = False
             return
 
@@ -164,4 +172,8 @@ class NoseExclude(Plugin):
         if fqn in self.exclude_tests:
             return False
         else:
+            for supercls in cls.mro():
+                fqn = '%s.%s' % (supercls.__module__, supercls.__name__)
+                if fqn in self.exclude_superclasses:
+                    return False
             return None

--- a/test_dirs/supercls/tests.py
+++ b/test_dirs/supercls/tests.py
@@ -1,0 +1,16 @@
+import unittest
+
+
+class TestBase(unittest.TestCase):
+    def setUp(self):
+        super(TestBase, self).setUp()
+        return None
+
+
+class SuperclsTests(TestBase):
+    def test_a(self):
+        assert True
+
+
+def test_b(self):
+    assert True

--- a/tests.py
+++ b/tests.py
@@ -224,5 +224,18 @@ class TestNoseExcludeTestModule(PluginTester, unittest.TestCase):
     def test_tests_excluded(self):
         assert 'Ran 3 tests' in self.output
 
+
+class TestNoseExcludeTestSuperclass(PluginTester, unittest.TestCase):
+    """Test nose-exclude tests by superclass"""
+
+    activate = "--exclude-test-superclass=test_dirs.supercls.tests.TestBase"
+
+    plugins = [NoseExclude()]
+    suitepath = os.path.join(os.getcwd(), 'test_dirs/supercls')
+
+    def test_tests_excluded(self):
+        assert 'Ran 1 test' in self.output
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The use-case which prompted this was excluding all tests that descended from `django.test.TestCase`, so I could do a library-only test run in a project without the overhead of setting up a Django test database. Let me know if it's not really in the spirit of this plugin.
